### PR TITLE
Add expo-image dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "expo-build-properties": "~0.14.8",
         "expo-constants": "~17.1.7",
         "expo-font": "~13.3.2",
+        "expo-image": "~2.4.0",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.4",
         "expo-splash-screen": "~0.30.10",
@@ -1130,6 +1131,8 @@
     "expo-file-system": ["expo-file-system@18.1.11", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ=="],
 
     "expo-font": ["expo-font@13.3.2", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A=="],
+
+    "expo-image": ["expo-image@2.4.0", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw=="],
 
     "expo-json-utils": ["expo-json-utils@0.15.0", "", {}, "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"expo-build-properties": "~0.14.8",
 		"expo-constants": "~17.1.7",
 		"expo-font": "~13.3.2",
-		"expo-image": "~2.5.0",
+		"expo-image": "~2.4.0",
 		"expo-linking": "~7.1.7",
 		"expo-router": "~5.1.4",
 		"expo-splash-screen": "~0.30.10",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"expo-build-properties": "~0.14.8",
 		"expo-constants": "~17.1.7",
 		"expo-font": "~13.3.2",
+		"expo-image": "~2.5.0",
 		"expo-linking": "~7.1.7",
 		"expo-router": "~5.1.4",
 		"expo-splash-screen": "~0.30.10",


### PR DESCRIPTION
Add missing `expo-image` dependency with the correct version for Expo SDK 53.

---
<a href="https://cursor.com/background-agent?bcId=bc-3900f76e-b114-4ab9-a5fb-8bbef434f707">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3900f76e-b114-4ab9-a5fb-8bbef434f707">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

