### PR TITLE
Integrate keyboard controller for sign in page

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,8 +71,9 @@
 					"resizeMode": "contain"
 				}
 			],
-			"react-native-edge-to-edge"
-		],
+							"react-native-edge-to-edge",
+				"react-native-keyboard-controller"
+			],
 		"runtimeVersion": {
 			"policy": "fingerprint"
 		},

--- a/app.json
+++ b/app.json
@@ -71,9 +71,9 @@
 					"resizeMode": "contain"
 				}
 			],
-							"react-native-edge-to-edge",
-				"react-native-keyboard-controller"
-			],
+			"react-native-edge-to-edge",
+			"react-native-keyboard-controller"
+		],
 		"runtimeVersion": {
 			"policy": "fingerprint"
 		},

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,6 +13,7 @@ module.exports = (api) => {
 				},
 			],
 			'@lingui/babel-plugin-lingui-macro',
+			'react-native-reanimated/plugin',
 		],
 		presets: [['babel-preset-expo']],
 	}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"react-native-gesture-handler": "~2.24.0",
 		"react-native-ios-context-menu": "3.1.2",
 		"react-native-ios-utilities": "5.1.8",
+		"react-native-keyboard-controller": "^1.18.3",
 		"react-native-mmkv": "3.3.0",
 		"react-native-nitro-modules": "0.27.4",
 		"react-native-reanimated": "~3.17.4",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -9,7 +9,6 @@ import {
 	ThemeProvider,
 } from '@react-navigation/native'
 import * as Sentry from '@sentry/react-native'
-import 'react-native-reanimated'
 import { Stack, useNavigationContainerRef } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { KeyboardProvider } from 'react-native-keyboard-controller'

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -12,6 +12,7 @@ import * as Sentry from '@sentry/react-native'
 import 'react-native-reanimated'
 import { Stack, useNavigationContainerRef } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
+import { KeyboardProvider } from 'react-native-keyboard-controller'
 
 import { LanguageProvider } from '@/lib/contexts/language-context'
 import { useColorScheme } from '@/lib/hooks/use-color-scheme'
@@ -56,32 +57,34 @@ function RootLayout() {
 
 	return (
 		<QueryProvider>
-			<LanguageProvider>
-				<I18nProvider i18n={i18n}>
-					<ThemeProvider
-						value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
-					>
-						<StatusBar style="auto" />
-						<Stack>
-							<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-							<Stack.Screen name="+not-found" />
-							<Stack.Screen
-								name="sign-in"
-								options={{
-									animation: Platform.select({
-										default: undefined,
-										web: 'fade',
-									}),
-									presentation: Platform.select({
-										default: 'modal',
-										web: 'transparentModal',
-									}),
-								}}
-							/>
-						</Stack>
-					</ThemeProvider>
-				</I18nProvider>
-			</LanguageProvider>
+			<KeyboardProvider statusBarTranslucent={Platform.OS === 'android'}>
+				<LanguageProvider>
+					<I18nProvider i18n={i18n}>
+						<ThemeProvider
+							value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+						>
+							<StatusBar style="auto" />
+							<Stack>
+								<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+								<Stack.Screen name="+not-found" />
+								<Stack.Screen
+									name="sign-in"
+									options={{
+										animation: Platform.select({
+											default: undefined,
+											web: 'fade',
+										}),
+										presentation: Platform.select({
+											default: 'modal',
+											web: 'transparentModal',
+										}),
+									}}
+								/>
+							</Stack>
+						</ThemeProvider>
+					</I18nProvider>
+				</LanguageProvider>
+			</KeyboardProvider>
 		</QueryProvider>
 	)
 }

--- a/src/app/sign-in.tsx
+++ b/src/app/sign-in.tsx
@@ -7,6 +7,7 @@ import {
 	TouchableOpacity,
 	View,
 } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-controller'
 
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useForm } from '@tanstack/react-form'
@@ -115,7 +116,7 @@ export default function SignIn() {
 				</View>
 			)}
 
-			<View style={styles.content}>
+			<KeyboardAwareScrollView contentContainerStyle={styles.content}>
 				<View style={styles.authContainer}>
 					{stage === 'phone' ? (
 						<>
@@ -223,7 +224,7 @@ export default function SignIn() {
 						</>
 					)}
 				</View>
-			</View>
+			</KeyboardAwareScrollView>
 		</View>
 	)
 }
@@ -252,7 +253,7 @@ const styles = StyleSheet.create((theme) => ({
 		padding: theme.layout.screenPadding,
 	},
 	content: {
-		flex: 1,
+		flexGrow: 1,
 		justifyContent: 'center',
 	},
 	errorText: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'react-native-reanimated'
 import '@/lib/sentry'
 import '@/lib/styles/unistyles'
 


### PR DESCRIPTION
Integrate `react-native-keyboard-controller` to enable automatic scrolling of the sign-in form when the keyboard is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-14fbb5ad-ecf9-4149-a02a-db89e962d255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14fbb5ad-ecf9-4149-a02a-db89e962d255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

