### PR TITLE
Setup maestro and eas end-to-end tests

### DIFF
--- a/.eas/workflows/e2e-test-android.yml
+++ b/.eas/workflows/e2e-test-android.yml
@@ -1,0 +1,22 @@
+name: e2e-test-android
+
+on:
+  pull_request:
+    branches: ['*']
+  workflow_dispatch: {}
+
+jobs:
+  build_android_for_e2e:
+    name: Build Android APK for E2E tests
+    type: build
+    params:
+      platform: android
+      profile: e2e-test
+
+  maestro_test:
+    name: Run Maestro E2E tests
+    needs: [build_android_for_e2e]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
+      flow_path: ['.maestro/app-launch.yml', '.maestro/navigation-flow.yml']

--- a/.eas/workflows/e2e-test-ios.yml
+++ b/.eas/workflows/e2e-test-ios.yml
@@ -1,0 +1,22 @@
+name: e2e-test-ios
+
+on:
+  pull_request:
+    branches: ['*']
+  workflow_dispatch: {}
+
+jobs:
+  build_ios_for_e2e:
+    name: Build iOS Simulator for E2E tests
+    type: build
+    params:
+      platform: ios
+      profile: e2e-test
+
+  maestro_test:
+    name: Run Maestro E2E tests
+    needs: [build_ios_for_e2e]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
+      flow_path: ['.maestro/app-launch.yml', '.maestro/navigation-flow.yml']

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,109 @@
+# E2E Testing with Maestro
+
+This directory contains End-to-End (E2E) tests for the TOLO coffee shop app using [Maestro](https://maestro.mobile.dev/).
+
+## Test Files
+
+- `app-launch.yml` - Basic app launch test that verifies the app starts and main elements are visible
+- `navigation-flow.yml` - Tests navigation between main tabs (Home, Orders, More)
+
+## Local Testing
+
+### Prerequisites
+
+1. Install Maestro CLI:
+
+   ```bash
+   curl -Ls "https://get.maestro.mobile.dev" | bash
+   ```
+
+2. Start an Android emulator or iOS simulator
+
+3. Install the app on your device/simulator:
+   ```bash
+   # For development builds
+   bun run android
+   # or
+   bun run ios
+   ```
+
+### Running Tests
+
+Run all tests:
+
+```bash
+bun run e2e:test
+```
+
+Run a specific test:
+
+```bash
+maestro test .maestro/app-launch.yml
+```
+
+## EAS Workflows
+
+The project includes automated E2E testing workflows that run on EAS:
+
+- `.eas/workflows/e2e-test-android.yml` - Android E2E testing workflow
+- `.eas/workflows/e2e-test-ios.yml` - iOS E2E testing workflow
+
+### Running E2E Tests on EAS
+
+Build and test Android:
+
+```bash
+bun run e2e:test:android
+```
+
+Build and test iOS:
+
+```bash
+bun run e2e:test:ios
+```
+
+Build only (without running tests):
+
+```bash
+bun run e2e:build:android
+bun run e2e:build:ios
+```
+
+### Workflow Triggers
+
+The E2E workflows automatically run on:
+
+- Pull requests to any branch
+- Manual trigger via `workflow_dispatch`
+
+## Build Profile
+
+The `e2e-test` build profile in `eas.json` is configured to:
+
+- Build without credentials (for testing only)
+- Create APK for Android (suitable for emulators)
+- Create simulator build for iOS
+- Use the same Node.js and bun versions as other profiles
+
+## Adding New Tests
+
+1. Create new `.yml` files in the `.maestro/` directory
+2. Add the new test file path to the workflow files in `.eas/workflows/`
+3. Test locally first before pushing to ensure tests work correctly
+
+## Test Structure
+
+Maestro tests use YAML format with the following structure:
+
+```yaml
+appId: cafe.tolo.app # App bundle identifier
+---
+- launchApp # Launch the application
+- assertVisible: 'Text' # Assert text is visible
+- tapOn: 'Button' # Tap on element
+- scrollUntilVisible: # Scroll to find element
+    element: 'Text'
+    direction: DOWN
+```
+
+For more advanced testing patterns, refer to the [Maestro documentation](https://maestro.mobile.dev/api-reference).

--- a/.maestro/app-launch.yml
+++ b/.maestro/app-launch.yml
@@ -1,0 +1,7 @@
+appId: cafe.tolo.app
+---
+- launchApp
+- assertVisible: 'TOLO'
+- assertVisible: 'Menu'
+- assertVisible: 'Store'
+- assertVisible: 'Contact'

--- a/.maestro/navigation-flow.yml
+++ b/.maestro/navigation-flow.yml
@@ -1,0 +1,20 @@
+appId: cafe.tolo.app
+---
+# Test app launch and basic navigation
+- launchApp
+- assertVisible: 'TOLO'
+
+# Test Home tab is active by default
+- assertVisible: 'Home'
+
+# Test Orders tab navigation
+- tapOn: 'Orders'
+- assertVisible: 'Orders'
+
+# Test More tab navigation
+- tapOn: 'More'
+- assertVisible: 'More'
+
+# Return to Home tab
+- tapOn: 'Home'
+- assertVisible: 'Home'

--- a/eas.json
+++ b/eas.json
@@ -19,6 +19,16 @@
 			"autoIncrement": true,
 			"channel": "production",
 			"extends": "common"
+		},
+		"e2e-test": {
+			"withoutCredentials": true,
+			"extends": "common",
+			"ios": {
+				"simulator": true
+			},
+			"android": {
+				"buildType": "apk"
+			}
 		}
 	},
 	"cli": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
 		"update:publish": "eas update --auto",
 		"clean": "rm -rf node_modules ios dist .wrangler coverage android .expo && bun install",
 		"sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=tolo-cafe --project=workers && sentry-cli sourcemaps upload --org=tolo-cafe --project=workers --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
-		"postdeploy": "bun run sentry:sourcemaps"
+		"postdeploy": "bun run sentry:sourcemaps",
+		"e2e:test": "maestro test .maestro/",
+		"e2e:test:android": "eas workflow:run .eas/workflows/e2e-test-android.yml",
+		"e2e:test:ios": "eas workflow:run .eas/workflows/e2e-test-ios.yml",
+		"e2e:build:android": "eas build --platform android --profile e2e-test",
+		"e2e:build:ios": "eas build --platform ios --profile e2e-test"
 	},
 	"dependencies": {
 		"@aws-sdk/client-sns": "3.879.0",


### PR DESCRIPTION
Add Maestro E2E tests and EAS workflows to automate end-to-end testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-56df4da3-44a7-4cee-849a-a9e7894917d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56df4da3-44a7-4cee-849a-a9e7894917d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

